### PR TITLE
Avoid triggering change detection unless necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/**/*.js
 e2e/**/*.js
 e2e/**/*.js.map
 coverage
+.idea/

--- a/src/lib/src/shared/event-data.ts
+++ b/src/lib/src/shared/event-data.ts
@@ -10,8 +10,8 @@ export const eventPathResize = [
   '$event.target.scrollY',
   '$event.target.scrollX'
 ];
-export const eventWindowResize = 'window:resize';
-export const eventWindowScroll = 'window:scroll';
+export const eventWindowResize = 'resize';
+export const eventWindowScroll = 'scroll';
 export const inViewportClass = 'class.sn-viewport-in';
 export const notInViewportClass = 'class.sn-viewport-out';
 

--- a/src/lib/src/testing/dom.ts
+++ b/src/lib/src/testing/dom.ts
@@ -1,0 +1,24 @@
+export class FakeDOMStandardElement {
+  private listeners: object;
+  private nodeName: string;
+
+  constructor(nodeName: string) {
+    this.listeners = {};
+    this.nodeName = nodeName;
+  }
+
+  addEventListener(eventName: string, handler: any, useCapture: boolean) {
+    this.listeners[eventName] = handler;
+  }
+
+  removeEventListener(eventName: string, handler: any, useCapture: boolean) {
+    delete this.listeners[eventName];
+  }
+
+  trigger(eventName: string) {
+    let args = Array.prototype.slice.call(arguments, 1);
+    if (eventName in this.listeners) {
+      this.listeners[eventName].apply(null, args);
+    }
+  }
+}

--- a/src/lib/src/testing/mock-ng-zone.ts
+++ b/src/lib/src/testing/mock-ng-zone.ts
@@ -1,0 +1,11 @@
+import { EventEmitter, NgZone } from '@angular/core';
+
+export class MockNgZone extends NgZone {
+  private _mockOnStable: EventEmitter<any> = new EventEmitter(false);
+  constructor() { super({enableLongStackTrace: false}); }
+  set onStable(v) {}
+  get onStable() { return this._mockOnStable; }
+  run(fn: Function): any { return fn(); }
+  runOutsideAngular(fn: Function): any { return fn(); }
+  simulateZoneExit(): void { this.onStable.emit(null); }
+}


### PR DESCRIPTION
Great work on this! I added the scroll spy directive to our app, and while it mostly worked great, I noticed a significant performance degradation when scrolling.

After digging in a bit, I see the reason is the `snInViewport` directive was using `@HostListener` to listen for window scroll and resize events. These events are not throttled, and they trigger a full change detection cycle for the entire application, resulting in poor performance (see discussion [here](https://github.com/angular/angular/issues/1773) and [here](https://github.com/angular/angular/issues/13248)).

The fix is motivated by angular material's approach to handling the same problem. Check the `ScrollDispatcher` service:

https://github.com/angular/material2/blob/master/src/cdk/scrolling/scroll-dispatcher.ts

Particularly this comment:

    * **Note:** in order to avoid hitting change detection for every scroll event,
    * all of the events emitted from this stream will be run outside the Angular zone.
    * If you need to update any data bindings as a result of a scroll event, you have
    * to run the callback using `NgZone.run`.
    */

So, the fix here is to replace `@HostListener` with `Observable.fromEvent` which allows a bit more control over throttling, and to run the handler outside the Angular zone (using [`NgZone.runOutsideAngular`](https://angular.io/api/core/NgZone#runOutsideAngular)) to avoid triggering change detection. Then, only if the in-viewport status changes, we re-enter the Angular zone using [`NgZone.run`](https://angular.io/api/core/NgZone#run), which will trigger change detection.